### PR TITLE
Add start/end date commandline options

### DIFF
--- a/flatex-fetch.py
+++ b/flatex-fetch.py
@@ -132,12 +132,17 @@ class Fetcher(object):
             idx += 1
 
     def iter_all_download_urls(self, start_date=None, end_date=None, days=None):
-        if end_date is None:
+        if end_date is not None:
+            end_date = date.fromisoformat(end_date)
+        else:
             end_date = date.today()
-        if days is not None:
+
+        if start_date is not None:
+            start_date = date.fromisoformat(start_date)
+        elif days is not None:
             start_date = end_date - timedelta(days=days)
-        if start_date is None:
-            raise TypeError("no start date")
+        else:
+            raise RuntimeError("no start date")
 
         for start_date, end_date in _iter_dates(start_date, end_date):
             for url in self.iter_download_urls(start_date, end_date):
@@ -240,7 +245,9 @@ class Fetcher(object):
 @click.option(
     "--days", help="How many days of PDFs to download", default=90, show_default=True
 )
-def cli(session_id, userid, password, output, days, csv):
+@click.option("--start", help="Date when to start downloading PDFs (format: 2021-01-15)")
+@click.option("--end", help="Date when to stop downloading PDFs (format: 2021-06-24)")
+def cli(session_id, userid, password, output, days, csv, start, end):
     """A utility to download PDFs from flatex.at.
     
     The default behavior is to download PDFs but optionally with --csv
@@ -259,7 +266,7 @@ def cli(session_id, userid, password, output, days, csv):
         else:
             click.abort("")
     else:
-        fetcher.download_all(output, days=days)
+        fetcher.download_all(output, days=days, start_date=start, end_date=end)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Problem:
Currently, the script downloads PDFs from the last N days, where N is specified using the `--days` flag. Flatex seems to rate-limit PDF downloads, which makes it impossible to get a complete history if you have a lot of trades.

Solution:
Add `--start` and `--end` flags. The script already uses these terms, so only minimal wiring is necessary to get it to work.

Testing:
Ran

```
$ python flatex-fetch.py \
  --session-id [omitted] \
  --start 2021-01-01 \
  --end 2021-01-31
```

and saw PDFs from that range being downloaded.